### PR TITLE
feat: sorting search params before navigating

### DIFF
--- a/.changeset/curvy-icons-protect.md
+++ b/.changeset/curvy-icons-protect.md
@@ -1,0 +1,5 @@
+---
+"sveltekit-search-params": minor
+---
+
+feat: sorting search params before navigating

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules
 
 # Local Netlify folder
 .netlify
+test-results

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ The simplest and most effective way to use this library is by importing the meth
 
 ```svelte
 <script lang="ts">
-    import { queryParam } from "sveltekit-search-params";
+	import { queryParam } from 'sveltekit-search-params';
 
-    const username = queryParam("username");
+	const username = queryParam('username');
 </script>
 
 Your username is {$username}
@@ -62,9 +62,9 @@ Reading query parameters is cool but you know what is even cooler? Writing query
 
 ```svelte
 <script lang="ts">
-    import { queryParam } from "sveltekit-search-params";
+	import { queryParam } from 'sveltekit-search-params';
 
-    const username = queryParam("username");
+	const username = queryParam('username');
 </script>
 
 Your username is {$username}
@@ -75,16 +75,18 @@ or if you prefer
 
 ```svelte
 <script lang="ts">
-    import { queryParam } from "sveltekit-search-params";
+	import { queryParam } from 'sveltekit-search-params';
 
-    const username = queryParam("username");
+	const username = queryParam('username');
 </script>
 
-
 Your username is {$username}
-<input value={$username} on:input={(e)=>{
-    $username = e.target.value;
-}} />
+<input
+	value={$username}
+	on:input={(e) => {
+		$username = e.target.value;
+	}}
+/>
 ```
 
 ### Encoding and decoding
@@ -93,16 +95,16 @@ By default query parameters are strings but more often than not tho we are not w
 
 ```svelte
 <script lang="ts">
-    import { queryParam } from "sveltekit-search-params";
+	import { queryParam } from 'sveltekit-search-params';
 
-    const count = queryParam("count", {
-        encode: (value: number) => value.toString(),
-        decode: (value: string | null) => value ? parseInt(value) : null,
-    });
+	const count = queryParam('count', {
+		encode: (value: number) => value.toString(),
+		decode: (value: string | null) => (value ? parseInt(value) : null),
+	});
 </script>
 
 The count is {$count}
-<input bind:value={$count} type="number"/>
+<input bind:value={$count} type="number" />
 ```
 
 this time $count would be of type number and the deconding function it's what's used to update the url when you write to the store.
@@ -113,17 +115,17 @@ Sometimes when we want to create a new variable we like to pass a default value.
 
 ```svelte
 <script lang="ts">
-    import { queryParam } from "sveltekit-search-params";
+	import { queryParam } from 'sveltekit-search-params';
 
-    const count = queryParam("count", {
-        encode: (value: number) => value.toString(),
-        decode: (value: string | null) => value ? parseInt(value) : null,
-        defaultValue: 10,
-    });
+	const count = queryParam('count', {
+		encode: (value: number) => value.toString(),
+		decode: (value: string | null) => (value ? parseInt(value) : null),
+		defaultValue: 10,
+	});
 </script>
 
 The count is {$count}
-<input bind:value={$count} type="number"/>
+<input bind:value={$count} type="number" />
 ```
 
 this will make the query parameter change as soon as the page is rendered on the browser (the query parameter will change only if it's not already present and only the first time the application render).
@@ -138,13 +140,13 @@ Write an encode and decode function may seem trivial but it's tedious for sure. 
 
 ```svelte
 <script lang="ts">
-    import { ssp, queryParam } from "sveltekit-search-params";
+	import { ssp, queryParam } from 'sveltekit-search-params';
 
-    const count = queryParam("count", ssp.number());
+	const count = queryParam('count', ssp.number());
 </script>
 
 The count is {$count}
-<input bind:value={$count} type="number"/>
+<input bind:value={$count} type="number" />
 ```
 
 this code will produce the same output as the code written above but far more readable and easier to read. You can find all the exports documented in the section [ssp - Helpers](#ssp---helpers).
@@ -153,13 +155,13 @@ You can also pass a default value to the function that will be the defaultValue 
 
 ```svelte
 <script lang="ts">
-    import { ssp, queryParam } from "sveltekit-search-params";
+	import { ssp, queryParam } from 'sveltekit-search-params';
 
-    const count = queryParam("count", ssp.number(10));
+	const count = queryParam('count', ssp.number(10));
 </script>
 
 The count is {$count}
-<input bind:value={$count} type="number"/>
+<input bind:value={$count} type="number" />
 ```
 
 ### Simple case (all parameters)
@@ -168,9 +170,9 @@ You can use the function queryParameters to get an object containing all the pre
 
 ```svelte
 <script lang="ts">
-    import { queryParameters } from "sveltekit-search-params";
+	import { queryParameters } from 'sveltekit-search-params';
 
-    const store = queryParameters();
+	const store = queryParameters();
 </script>
 
 <pre>
@@ -195,17 +197,20 @@ Just like with the single parameter case you can just update the store and the U
 
 ```svelte
 <script lang="ts">
-    import { queryParameters } from "sveltekit-search-params";
+	import { queryParameters } from 'sveltekit-search-params';
 
-    const store = queryParameters();
+	const store = queryParameters();
 </script>
 
 <pre>
     {JSON.stringify($store, null, 2)}
 </pre>
-<input value={$store.username} on:input={(e)=>{
-    $store.username = e.target.value;
-}} />
+<input
+	value={$store.username}
+	on:input={(e) => {
+		$store.username = e.target.value;
+	}}
+/>
 ```
 
 writing in the input will update the state and the URL at the same time.
@@ -216,11 +221,11 @@ Most of the times if you need to read from query parameters you are expecting so
 
 ```svelte
 <script lang="ts">
-    import { queryParameters } from "sveltekit-search-params";
+	import { queryParameters } from 'sveltekit-search-params';
 
-    const store = queryParameters({
-        username: true,
-    });
+	const store = queryParameters({
+		username: true,
+	});
 </script>
 
 <pre>
@@ -254,16 +259,17 @@ The parameter passed to `queryParameters` can aslo be used to specify the encodi
 
 ```svelte
 <script lang="ts">
-    import { queryParameters } from "sveltekit-search-params";
+	import { queryParameters } from 'sveltekit-search-params';
 
-    const store = queryParameters({
-        username: true,
-        isCool: {
-            encode: (booleanValue) => booleanValue.toString(),
-            decode: (stringValue) => stringValue !== null && stringValue !== "false",
-            defautValue: true,
-        }
-    });
+	const store = queryParameters({
+		username: true,
+		isCool: {
+			encode: (booleanValue) => booleanValue.toString(),
+			decode: (stringValue) =>
+				stringValue !== null && stringValue !== 'false',
+			defautValue: true,
+		},
+	});
 </script>
 
 <pre>
@@ -297,12 +303,12 @@ Obviously also in this case you can use the helpers functions provided inside `s
 
 ```svelte
 <script lang="ts">
-    import { ssp, queryParameters } from "sveltekit-search-params";
+	import { ssp, queryParameters } from 'sveltekit-search-params';
 
-    const store = queryParameters({
-        username: true,
-        isCool: ssp.boolean(true),
-    });
+	const store = queryParameters({
+		username: true,
+		isCool: ssp.boolean(true),
+	});
 </script>
 
 <pre>
@@ -385,25 +391,32 @@ The number of milliseconds to delay the writing of the history when the state ch
 
 A boolean defining if the history have to be written at all. If set to false no new history entries will be written to the history stack (the URL will still update but the user will not be able to go back with the browser).
 
+### sort
+
+Whenever you interacts with a store it navigates for you. By default the search params are sorted to allow for better cache-ability. You can disable this behavior by passing `false` to this option. Keep in mind that this is a per-store settings. This mean that if you interact with a store that has this option set to `false` and than interact with one that has this option set to `true` (the default) the resulting URL will still have the search params sorted.
+
 ### How to use it
 
 To set the configuration object you can pass it as a third parameter in case of `queryParam` or the second in case of `queryParameters`.
 
 ```svelte
 <script lang="ts">
-    import { ssp, queryParameters, queryParam } from "sveltekit-search-params";
-    const name = queryParam("name", ssp.string(), {
-        debounceHistory: 500, //a new history entry will be created after 500ms of this store not changing
-    });
-    const count = queryParam("count", ssp.number(), {
-        debounceHistory: 1500, //a new history entry will be created after 1500ms of this store not changing
-    })
-    const store = queryParameters({
-        username: true,
-        isCool: ssp.boolean(true),
-    }, {
-        pushHistory: false, //no new history entries for this store
-    });
+	import { ssp, queryParameters, queryParam } from 'sveltekit-search-params';
+	const name = queryParam('name', ssp.string(), {
+		debounceHistory: 500, //a new history entry will be created after 500ms of this store not changing
+	});
+	const count = queryParam('count', ssp.number(), {
+		debounceHistory: 1500, //a new history entry will be created after 1500ms of this store not changing
+	});
+	const store = queryParameters(
+		{
+			username: true,
+			isCool: ssp.boolean(true),
+		},
+		{
+			pushHistory: false, //no new history entries for this store
+		},
+	);
 </script>
 ```
 

--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ A boolean defining if the history have to be written at all. If set to false no 
 
 ### sort
 
-Whenever you interacts with a store it navigates for you. By default the search params are sorted to allow for better cache-ability. You can disable this behavior by passing `false` to this option. Keep in mind that this is a per-store settings. This mean that if you interact with a store that has this option set to `false` and than interact with one that has this option set to `true` (the default) the resulting URL will still have the search params sorted.
+Whenever you interact with a store, it navigates for you. By default the search params are sorted to allow for better cache-ability. You can disable this behavior by passing `false` to this option. Keep in mind that this is a per-store settings. This mean that if you interact with a store that has this option set to `false` and than interact with one that has this option set to `true` (the default) the resulting URL will still have the search params sorted.
 
 ### How to use it
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ The parameter passed to `queryParameters` can aslo be used to specify the encodi
 			encode: (booleanValue) => booleanValue.toString(),
 			decode: (stringValue) =>
 				stringValue !== null && stringValue !== 'false',
-			defautValue: true,
+			defaultValue: true,
 		},
 	});
 </script>

--- a/package.json
+++ b/package.json
@@ -34,8 +34,10 @@
 		"format": "prettier --write .",
 		"publish": "pnpm run build && changeset publish",
 		"test": "npm run test:integration && npm run test:unit",
+		"test:integration:ui": "playwright test --ui",
 		"test:integration": "playwright test",
-		"test:unit": "vitest"
+		"test:unit": "vitest",
+		"changeset": "changeset"
 	},
 	"devDependencies": {
 		"@changesets/cli": "^2.26.0",

--- a/playground/src/routes/+page.svelte
+++ b/playground/src/routes/+page.svelte
@@ -6,6 +6,9 @@
 	const bools = queryParam('bools', ssp.boolean());
 	const obj = queryParam('obj', ssp.object<{ str: string }>());
 	const arr = queryParam('arr', ssp.array<number>());
+	const arr_unordered = queryParam('arr-unordered', ssp.array<number>(), {
+		sort: false,
+	});
 	const lz = queryParam('lz', ssp.lz<string>());
 </script>
 
@@ -41,6 +44,22 @@
 <ul>
 	{#each $arr ?? [] as num}
 		<li data-testid="arr">{num}</li>
+	{/each}
+</ul>
+
+<button
+	on:click={() => {
+		if (!$arr_unordered) {
+			$arr_unordered = [];
+		}
+		$arr_unordered.push($arr_unordered.length);
+		$arr_unordered = $arr_unordered;
+	}}
+	data-testid="arr-unordered-input">Add unordered array</button
+>
+<ul>
+	{#each $arr_unordered ?? [] as num}
+		<li data-testid="arr-unordered">{num}</li>
 	{/each}
 </ul>
 

--- a/playground/src/routes/queryparameters/+page.svelte
+++ b/playground/src/routes/queryparameters/+page.svelte
@@ -9,6 +9,15 @@
 		arr: ssp.array<number>(),
 		lz: ssp.lz<string>(),
 	});
+
+	const unordered_store = queryParameters(
+		{
+			'arr-unordered': ssp.array<number>(),
+		},
+		{
+			sort: false,
+		},
+	);
 </script>
 
 <input data-testid="str-input" bind:value={$store.str} />
@@ -43,6 +52,24 @@
 <ul>
 	{#each $store.arr ?? [] as num}
 		<li data-testid="arr">{num}</li>
+	{/each}
+</ul>
+
+<button
+	on:click={() => {
+		if (!$unordered_store['arr-unordered']) {
+			$unordered_store['arr-unordered'] = [];
+		}
+		$unordered_store['arr-unordered'].push(
+			$unordered_store['arr-unordered'].length,
+		);
+		$unordered_store['arr-unordered'] = $unordered_store['arr-unordered'];
+	}}
+	data-testid="arr-unordered-input">Add unordered array</button
+>
+<ul>
+	{#each $unordered_store['arr-unordered'] ?? [] as num}
+		<li data-testid="arr-unordered">{num}</li>
 	{/each}
 </ul>
 

--- a/src/lib/sveltekit-search-params.ts
+++ b/src/lib/sveltekit-search-params.ts
@@ -30,6 +30,7 @@ export type EncodeAndDecodeOptions<T = any> = {
 export type StoreOptions = {
 	debounceHistory?: number;
 	pushHistory?: boolean;
+	sort?: boolean;
 };
 
 type LooseAutocomplete<T> = {
@@ -156,7 +157,7 @@ const debouncedTimeouts = new Map<string, SetTimeout>();
 
 export function queryParameters<T extends object>(
 	options?: Options<T>,
-	{ debounceHistory = 0, pushHistory = true }: StoreOptions = {},
+	{ debounceHistory = 0, pushHistory = true, sort = true }: StoreOptions = {},
 ): Writable<LooseAutocomplete<T>> {
 	function set(value: T) {
 		if (!browser) return;
@@ -192,11 +193,19 @@ export function queryParameters<T extends object>(
 				batched(query);
 			});
 			clearTimeout(debouncedTimeouts.get('queryParameters'));
-			if (browser) await goto(`?${query}${hash}`, GOTO_OPTIONS);
+			if (browser) {
+				if (sort) {
+					query.sort();
+				}
+				await goto(`?${query}${hash}`, GOTO_OPTIONS);
+			}
 			if (pushHistory && browser) {
 				debouncedTimeouts.set(
 					'queryParameters',
 					setTimeout(() => {
+						if (sort) {
+							query.sort();
+						}
 						goto(hash, GOTO_OPTIONS_PUSH);
 					}, debounceHistory),
 				);
@@ -237,7 +246,7 @@ export function queryParam<T = string>(
 		decode: decode = DEFAULT_ENCODER_DECODER.decode,
 		defaultValue,
 	}: EncodeAndDecodeOptions<T> = DEFAULT_ENCODER_DECODER,
-	{ debounceHistory = 0, pushHistory = true }: StoreOptions = {},
+	{ debounceHistory = 0, pushHistory = true, sort = true }: StoreOptions = {},
 ): Writable<T | null> {
 	function set(value: T | null) {
 		if (!browser) return;
@@ -262,11 +271,19 @@ export function queryParam<T = string>(
 				batched(query);
 			});
 			clearTimeout(debouncedTimeouts.get(name));
-			if (browser) await goto(`?${query}${hash}`, GOTO_OPTIONS);
+			if (browser) {
+				if (sort) {
+					query.sort();
+				}
+				await goto(`?${query}${hash}`, GOTO_OPTIONS);
+			}
 			if (pushHistory && browser) {
 				debouncedTimeouts.set(
 					name,
 					setTimeout(() => {
+						if (sort) {
+							query.sort();
+						}
 						goto(hash, GOTO_OPTIONS_PUSH);
 					}, debounceHistory),
 				);

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -116,6 +116,41 @@ test.describe('queryParam', () => {
 		expect(url.searchParams.get('str')).toBe('one');
 		expect(url.searchParams.get('num')).toBe('42');
 	});
+
+	test('parameters are kept in alphabetical order by default', async ({
+		page,
+	}) => {
+		await page.goto('/?num=0');
+		const arr_btn = page.getByTestId('arr-input');
+		const btn = page.getByTestId('num');
+		await btn.click();
+		await arr_btn.click();
+		const url = new URL(page.url());
+		expect(url.search).toBe('?arr=%5B0%5D&num=1');
+	});
+
+	test('parameters are not ordered if updated through a store that has specifically set sort to false', async ({
+		page,
+	}) => {
+		await page.goto('/');
+		const input = page.getByTestId('str-input');
+		await input.fill('str');
+		const btn = page.getByTestId('arr-unordered-input');
+		await btn.click();
+		const arr = page.getByTestId('arr-unordered');
+		expect(await arr.count()).toBe(1);
+		let url = new URL(page.url());
+		expect(url.searchParams.get('arr-unordered')).toBe('[0]');
+		expect(url.searchParams.get('str')).toBe('str');
+		expect(url.search).toBe('?str=str&arr-unordered=%5B0%5D');
+
+		// expect them to be ordered if you access an ordered store
+		await input.fill('string');
+		url = new URL(page.url());
+		expect(url.searchParams.get('arr-unordered')).toBe('[0]');
+		expect(url.searchParams.get('str')).toBe('string');
+		expect(url.search).toBe('?arr-unordered=%5B0%5D&str=string');
+	});
 });
 
 test.describe('queryParameters', () => {
@@ -232,5 +267,42 @@ test.describe('queryParameters', () => {
 		const url = new URL(page.url());
 		expect(url.searchParams.get('str')).toBe('one');
 		expect(url.searchParams.get('num')).toBe('42');
+	});
+
+	test('parameters are kept in alphabetical order by default', async ({
+		page,
+	}) => {
+		await page.goto('/queryparameters?num=0');
+		const arr_btn = page.getByTestId('arr-input');
+		const btn = page.getByTestId('num');
+		await btn.click();
+		await arr_btn.click();
+		const url = new URL(page.url());
+		expect(url.search).toBe('?arr=%5B0%5D&bools=false&num=1');
+	});
+
+	test('parameters are not ordered if updated through a store that has specifically set sort to false', async ({
+		page,
+	}) => {
+		await page.goto('/queryparameters');
+		const input = page.getByTestId('str-input');
+		await input.fill('str');
+		const btn = page.getByTestId('arr-unordered-input');
+		await btn.click();
+		const arr = page.getByTestId('arr-unordered');
+		expect(await arr.count()).toBe(1);
+		let url = new URL(page.url());
+		expect(url.searchParams.get('arr-unordered')).toBe('[0]');
+		expect(url.searchParams.get('str')).toBe('str');
+		expect(url.search).toBe('?bools=false&str=str&arr-unordered=%5B0%5D');
+
+		// expect them to be ordered if you access an ordered store
+		await input.fill('string');
+		url = new URL(page.url());
+		expect(url.searchParams.get('arr-unordered')).toBe('[0]');
+		expect(url.searchParams.get('str')).toBe('string');
+		expect(url.search).toBe(
+			'?arr-unordered=%5B0%5D&bools=false&str=string',
+		);
 	});
 });


### PR DESCRIPTION
Closes #51 

This adds sorting before navigating to allow for better cache-ability. This is technically a breaking change (?) but i'm a bit unsure about the consequences that it might have so i might keep it as a minor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the README to reflect changes in the usage of `queryParam` and `queryParameters` functions with improved examples.

- **New Features**
  - Introduced handling for new query parameter `arr_unordered` that maintains an unordered list.
  - Added a new `unordered_store` to manage the state of unordered arrays in the UI.

- **Refactor**
  - Enhanced the `queryParameters` and `queryParam` functions with a `sort` option to control the sorting of query parameters.

- **Tests**
  - Added tests to ensure the correct default and custom sorting of query parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->