### PR TITLE
fix: rework how defaults works

### DIFF
--- a/.changeset/wise-teachers-return.md
+++ b/.changeset/wise-teachers-return.md
@@ -1,0 +1,5 @@
+---
+"sveltekit-search-params": patch
+---
+
+fix: rework how defaults works

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 	"type": "module",
 	"peerDependencies": {
 		"@sveltejs/kit": "^1.0.0 || ^2.0.0",
-		"svelte": "^3.55.0 || ^4.0.0"
+		"svelte": "^3.55.0 || ^4.0.0 || ^5.0.0"
 	},
 	"exports": {
 		"./package.json": "./package.json",

--- a/playground/src/routes/default/+page.svelte
+++ b/playground/src/routes/default/+page.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	import { queryParam, ssp, queryParameters } from 'sveltekit-search-params';
+	const str = queryParam('str', ssp.string('def'));
+	const num = queryParam('num', ssp.number(42));
+	const store = queryParameters({
+		str2: ssp.string('str2'),
+	});
+</script>
+
+<span data-testid="str">{$str}</span>
+
+<span data-testid="num">{$num}</span>
+
+<span data-testid="str2">{$store.str2}</span>

--- a/src/lib/sveltekit-search-params.ts
+++ b/src/lib/sveltekit-search-params.ts
@@ -70,13 +70,10 @@ function mixSearchAndOptions<T>(
 				const value = searchParams?.get(key);
 				let actualValue;
 				if (
-					browser &&
 					value == undefined &&
-					optionsKey?.defaultValue != undefined &&
-					!defaultedParams.has(key)
+					optionsKey?.defaultValue != undefined
 				) {
 					actualValue = optionsKey.defaultValue;
-					defaultedParams.add(key);
 					anyDefaultedParam = true;
 				} else {
 					actualValue = fnToCall(value);
@@ -150,8 +147,6 @@ type SetTimeout = ReturnType<typeof setTimeout>;
 const batchedUpdates = new Set<(query: URLSearchParams) => void>();
 
 let batchTimeout: SetTimeout;
-
-const defaultedParams = new Set<string>();
 
 const debouncedTimeouts = new Map<string, SetTimeout>();
 
@@ -294,14 +289,8 @@ export function queryParam<T = string>(
 
 	const { subscribe } = derived(page, ($page) => {
 		const actualParam = $page?.url?.searchParams?.get?.(name);
-		if (
-			browser &&
-			actualParam == undefined &&
-			defaultValue != undefined &&
-			!defaultedParams.has(name)
-		) {
+		if (actualParam == undefined && defaultValue != undefined) {
 			set(defaultValue);
-			defaultedParams.add(name);
 			return defaultValue;
 		}
 		return decode(actualParam);

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -306,3 +306,42 @@ test.describe('queryParameters', () => {
 		);
 	});
 });
+
+test.describe('default values', () => {
+	test('defaults redirect immediately to the correct url if js is enabled', async ({
+		page,
+	}) => {
+		await page.goto('/default');
+		await page.waitForURL((url) => {
+			return (
+				url.searchParams.get('str') === 'def' &&
+				url.searchParams.get('num') === '42' &&
+				url.searchParams.get('str2') === 'str2'
+			);
+		});
+		const str = page.getByTestId('str');
+		const num = page.getByTestId('num');
+		const str2 = page.getByTestId('str2');
+		await expect(str).toHaveText('def');
+		await expect(num).toHaveText('42');
+		await expect(str2).toHaveText('str2');
+	});
+});
+
+test.describe('default values during ssr', () => {
+	test.use({
+		javaScriptEnabled: false,
+	});
+
+	test("defaults don' redirect but the value is still present", async ({
+		page,
+	}) => {
+		await page.goto('/default');
+		const str = page.getByTestId('str');
+		const num = page.getByTestId('num');
+		const str2 = page.getByTestId('str2');
+		await expect(str).toHaveText('def');
+		await expect(num).toHaveText('42');
+		await expect(str2).toHaveText('str2');
+	});
+});


### PR DESCRIPTION
This should close #41 and #49

I changed a bit how defaults works...there's still a navigation happenning if possible but the default value is still set as the value of the store. This helps with SSR and i removed the weird set of defaulted params which i guess is what was causing #41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced query parameter handling in the UI, allowing users to see and interact with dynamic content based on URL parameters.

- **Bug Fixes**
	- Improved the reliability of default value assignments for query parameters.

- **Tests**
	- Added new tests to verify proper behavior of default values during server-side rendering and various JavaScript settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->