### PR TITLE
breaking: remove double navigation, debounce navigate after timeout

### DIFF
--- a/.changeset/kind-horses-melt.md
+++ b/.changeset/kind-horses-melt.md
@@ -1,0 +1,6 @@
+---
+'sveltekit-search-params': major
+---
+
+breaking: remove double navigation, debounce navigate after timeout
+feat: add showDefaults option to chose wether to show the defaults or not in the URL

--- a/README.md
+++ b/README.md
@@ -395,6 +395,32 @@ A boolean defining if the history have to be written at all. If set to false no 
 
 Whenever you interact with a store, it navigates for you. By default the search params are sorted to allow for better cache-ability. You can disable this behavior by passing `false` to this option. Keep in mind that this is a per-store settings. This mean that if you interact with a store that has this option set to `false` and than interact with one that has this option set to `true` (the default) the resulting URL will still have the search params sorted.
 
+### showDefaults
+
+If you specify a default value for the search param and it's not present by default the library will immediately navigate to the url that contains the default search param. For example if you have this code
+
+```svelte
+<script lang="ts">
+	import { queryParam, ssp } from 'sveltekit-search-params';
+
+	const pageNum = queryParam('pageNum', ssp.number(0));
+</script>
+```
+
+and you navigate to `/` as soon as the page load it will be redirected to `/?pageNum=0`. If you prefer not to show the defaults in the URL you can set the `showDefaults` option to false.
+
+```svelte
+<script lang="ts">
+	import { queryParam, ssp } from 'sveltekit-search-params';
+
+	const pageNum = queryParam('pageNum', ssp.number(0), {
+		showDefaults: false,
+	});
+</script>
+```
+
+By doing so the store will still have a value of 0 if the search param is not present but the user will not be redirected to `/?pageNum=0`.
+
 ### How to use it
 
 To set the configuration object you can pass it as a third parameter in case of `queryParam` or the second in case of `queryParameters`.

--- a/playground/src/routes/debounce/+page.svelte
+++ b/playground/src/routes/debounce/+page.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import { queryParam, queryParameters, ssp } from 'sveltekit-search-params';
+	const str = queryParam('str', ssp.string(), {
+		debounceHistory: 1000,
+	});
+
+	const params = queryParameters(
+		{
+			str2: true,
+			num: ssp.number(0),
+		},
+		{ debounceHistory: 1000 },
+	);
+</script>
+
+<input data-testid="str-input" bind:value={$str} />
+<div data-testid="str">{$str}</div>
+
+<input data-testid="str2-input" bind:value={$params.str2} />
+<div data-testid="str2">{$params.str2}</div>
+
+<button
+	data-testid="num"
+	on:click={() => {
+		$params.num++;
+	}}>{$params.num}</button
+>
+
+<button
+	data-testid="change-both"
+	on:click={() => {
+		$params.num++;
+		$params.str2 = 'changed';
+	}}>change both</button
+>

--- a/playground/src/routes/default/+page.svelte
+++ b/playground/src/routes/default/+page.svelte
@@ -2,13 +2,26 @@
 	import { queryParam, ssp, queryParameters } from 'sveltekit-search-params';
 	const str = queryParam('str', ssp.string('def'));
 	const num = queryParam('num', ssp.number(42));
+	const str_no_show = queryParam('str-no-show', ssp.string('no-show'), {
+		showDefaults: false,
+	});
 	const store = queryParameters({
 		str2: ssp.string('str2'),
 	});
+	const store_no_show = queryParameters(
+		{
+			'str2-no-show': ssp.string('str2-no-show'),
+		},
+		{ showDefaults: false },
+	);
 </script>
 
 <span data-testid="str">{$str}</span>
 
+<span data-testid="str-no-show">{$str_no_show}</span>
+
 <span data-testid="num">{$num}</span>
 
 <span data-testid="str2">{$store.str2}</span>
+
+<span data-testid="str2-no-show">{$store_no_show['str2-no-show']}</span>

--- a/src/lib/sveltekit-search-params.ts
+++ b/src/lib/sveltekit-search-params.ts
@@ -214,22 +214,25 @@ export function queryParameters<T extends object>(
 			clearTimeout(debouncedTimeouts.get('queryParameters'));
 			if (browser) {
 				overrides.set(value);
-				debouncedTimeouts.set(
-					'queryParameters',
-					setTimeout(
-						async () => {
-							if (sort) {
-								query.sort();
-							}
-							await goto(
-								`?${query}${hash}`,
-								pushHistory ? GOTO_OPTIONS_PUSH : GOTO_OPTIONS,
-							);
-							overrides.set({});
-						},
-						changeImmediately ? 0 : debounceHistory,
-					),
-				);
+				// eslint-disable-next-line no-inner-declarations
+				async function navigate() {
+					if (sort) {
+						query.sort();
+					}
+					await goto(
+						`?${query}${hash}`,
+						pushHistory ? GOTO_OPTIONS_PUSH : GOTO_OPTIONS,
+					);
+					overrides.set({});
+				}
+				if (changeImmediately || debounceHistory === 0) {
+					navigate();
+				} else {
+					debouncedTimeouts.set(
+						'queryParameters',
+						setTimeout(navigate, debounceHistory),
+					);
+				}
 			}
 			batchedUpdates.clear();
 		});
@@ -305,22 +308,25 @@ export function queryParam<T = string>(
 			clearTimeout(debouncedTimeouts.get(name));
 			if (browser) {
 				override.set(value);
-				debouncedTimeouts.set(
-					name,
-					setTimeout(
-						async () => {
-							if (sort) {
-								query.sort();
-							}
-							await goto(
-								`?${query}${hash}`,
-								pushHistory ? GOTO_OPTIONS_PUSH : GOTO_OPTIONS,
-							);
-							override.set(null);
-						},
-						changeImmediately ? 0 : debounceHistory,
-					),
-				);
+				// eslint-disable-next-line no-inner-declarations
+				async function navigate() {
+					if (sort) {
+						query.sort();
+					}
+					await goto(
+						`?${query}${hash}`,
+						pushHistory ? GOTO_OPTIONS_PUSH : GOTO_OPTIONS,
+					);
+					override.set(null);
+				}
+				if (changeImmediately || debounceHistory === 0) {
+					navigate();
+				} else {
+					debouncedTimeouts.set(
+						name,
+						setTimeout(navigate, debounceHistory),
+					);
+				}
 			}
 			batchedUpdates.clear();
 		});

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -84,6 +84,7 @@ test.describe('queryParam', () => {
 		await expect(str).toHaveText('lz');
 		const input = page.getByTestId('lz-input');
 		await input.fill('lz changed');
+		await expect(str).toHaveText('lz changed');
 		const url = new URL(page.url());
 		expect(url.searchParams.get('lz')).toBe('EQGwXgBAxgFghgOwOYFMAmwg');
 		expect(url.searchParams.get('something')).toBe('else');
@@ -134,11 +135,13 @@ test.describe('queryParam', () => {
 	}) => {
 		await page.goto('/');
 		const input = page.getByTestId('str-input');
+		const str = page.getByTestId('str');
 		await input.fill('str');
 		const btn = page.getByTestId('arr-unordered-input');
 		await btn.click();
 		const arr = page.getByTestId('arr-unordered');
 		expect(await arr.count()).toBe(1);
+		await expect(str).toHaveText('str');
 		let url = new URL(page.url());
 		expect(url.searchParams.get('arr-unordered')).toBe('[0]');
 		expect(url.searchParams.get('str')).toBe('str');
@@ -146,6 +149,7 @@ test.describe('queryParam', () => {
 
 		// expect them to be ordered if you access an ordered store
 		await input.fill('string');
+		await expect(str).toHaveText('string');
 		url = new URL(page.url());
 		expect(url.searchParams.get('arr-unordered')).toBe('[0]');
 		expect(url.searchParams.get('str')).toBe('string');
@@ -236,6 +240,7 @@ test.describe('queryParameters', () => {
 		await expect(str).toHaveText('lz');
 		const input = page.getByTestId('lz-input');
 		await input.fill('lz changed');
+		await expect(str).toHaveText('lz changed');
 		const url = new URL(page.url());
 		expect(url.searchParams.get('lz')).toBe('EQGwXgBAxgFghgOwOYFMAmwg');
 		expect(url.searchParams.get('something')).toBe('else');
@@ -286,11 +291,13 @@ test.describe('queryParameters', () => {
 	}) => {
 		await page.goto('/queryparameters');
 		const input = page.getByTestId('str-input');
+		const str = page.getByTestId('str');
 		await input.fill('str');
 		const btn = page.getByTestId('arr-unordered-input');
 		await btn.click();
 		const arr = page.getByTestId('arr-unordered');
 		expect(await arr.count()).toBe(1);
+		await expect(str).toHaveText('str');
 		let url = new URL(page.url());
 		expect(url.searchParams.get('arr-unordered')).toBe('[0]');
 		expect(url.searchParams.get('str')).toBe('str');
@@ -298,6 +305,7 @@ test.describe('queryParameters', () => {
 
 		// expect them to be ordered if you access an ordered store
 		await input.fill('string');
+		await expect(str).toHaveText('string');
 		url = new URL(page.url());
 		expect(url.searchParams.get('arr-unordered')).toBe('[0]');
 		expect(url.searchParams.get('str')).toBe('string');


### PR DESCRIPTION
Also feat: add `showDefaults` option to avoid redirecting in case the search param is not present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `showDefaults` option to control the visibility of default parameter values in the URL.
  - Enhanced query parameter handling with debouncing capabilities.

- **Enhancements**
  - Improved the display and management of query parameters in the user interface.

- **Documentation**
  - Updated README with information about the new `showDefaults` option.

- **Tests**
  - Expanded test coverage to include new functionality and ensure proper behavior of the `showDefaults` feature.
  - Refined test descriptions and assertions for better clarity and accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->