### PR TITLE
fix: allow building the app in prerendering by faking the page store during building

### DIFF
--- a/.changeset/seven-hounds-help.md
+++ b/.changeset/seven-hounds-help.md
@@ -1,0 +1,5 @@
+---
+'sveltekit-search-params': patch
+---
+
+fix: allow building the app in prerendering by faking the page store during building

--- a/src/lib/sveltekit-search-params.ts
+++ b/src/lib/sveltekit-search-params.ts
@@ -1,19 +1,36 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { browser } from '$app/environment';
+import { browser, building } from '$app/environment';
 import { goto } from '$app/navigation';
-import { page } from '$app/stores';
+import { page as page_store } from '$app/stores';
+import type { Page } from '@sveltejs/kit';
 import {
 	derived,
 	get,
 	writable,
 	type Updater,
 	type Writable,
+	type Readable,
+	readable,
 } from 'svelte/store';
 import {
 	compressToEncodedURIComponent,
 	decompressFromEncodedURIComponent,
 } from './lz-string/index.js';
+
+// during building we fake the page store with an URL with no search params
+// as it should be during prerendering. This allow the application to still build
+// and the client side behavior is still persisted after the build
+let page: Readable<Pick<Page, 'url'>>;
+if (building) {
+	page = readable({
+		url: new URL(
+			'https://github.com/paoloricciuti/sveltekit-search-params',
+		),
+	});
+} else {
+	page = page_store;
+}
 
 const GOTO_OPTIONS = {
 	keepFocus: true,


### PR DESCRIPTION
Closes #67 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed an issue to enable app building in prerendering mode by simulating the page store.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->