### PR TITLE
Wait for previous navigation done before navigating to param with new updated value

### DIFF
--- a/playground/src/routes/paramOnNavigateBug/+page.svelte
+++ b/playground/src/routes/paramOnNavigateBug/+page.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
+	import { onDestroy } from 'svelte';
 	import { queryParam, ssp } from 'sveltekit-search-params';
 
 	const param1 = queryParam('param1', ssp.string());
 	const param2 = queryParam('param2', ssp.string());
 
-	param1.subscribe(() => {
+	const unsubscribe = param1.subscribe(() => {
 		param2.set('updated param2');
+	});
+
+	onDestroy(() => {
+		unsubscribe();
 	});
 </script>
 

--- a/playground/src/routes/paramOnNavigateBug/+page.svelte
+++ b/playground/src/routes/paramOnNavigateBug/+page.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import { queryParam, ssp } from 'sveltekit-search-params';
+
+	const param1 = queryParam('param1', ssp.string());
+	const param2 = queryParam('param2', ssp.string());
+
+	param1.subscribe(() => {
+		param2.set('updated param2');
+	});
+</script>
+
+<button
+	data-testid="update-params"
+	on:click={() => ($param1 = 'updated param1')}>Update params</button
+>

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -133,6 +133,26 @@ test.describe('queryParam', () => {
 		expect(url.hash).toBe('#test-hash');
 	});
 
+	test('changing multiple parameters due to subscribe updates params accordingly', async ({
+		page,
+	}) => {
+		await page.goto('/paramOnNavigateBug');
+		const btn = page.getByTestId('update-params');
+		await btn.click();
+
+		// expect(url.searchParams.get('param1')).toBe('');
+
+		await page.waitForURL(
+			(url) => {
+				return (
+					url.searchParams.get('param1') === 'updated param1' &&
+					url.searchParams.get('param2') === 'updated param2'
+				);
+			},
+			{ timeout: 1000 },
+		);
+	});
+
 	test("changing two parameters in the same function doesn't negate", async ({
 		page,
 	}) => {


### PR DESCRIPTION
This PR tries to solve the bug explained in issue: https://github.com/paoloricciuti/sveltekit-search-params/issues/71

The problem is that navigation is "overwritten" when there is another store update right after the previous one (for example when a component mounts that has a `bind:value` to a new store that uses `queryParam`.

The way I managed to solve it is by subscribing to the `navigating` store provided by Sveltekit. This way you can know if it's currently navigating to a different url or page. Then when this is the case in the `_set` action, I just subscribe to the same store again there to wait until navigating is back to false, and then perform the same `_set` action. This solved it for me!

Let me know if this is a viable solution. I'm no expert in Sveltekit's internals so I have no idea if this is a proper/safe fix with or without any side effects. I'm just creating a simple app that doesn't have any server routing. But this did solve it in my case.

Also I'm not sure if the same bug appears in the other provided store builder `queryParameters`. I'm not using that one but looking at the code it looks very similar, so maybe a similar fix will work there. But not sure. Let me know if this is any good 😅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved navigation responsiveness by ensuring updates only occur when navigation is not in progress.
- **New Features**
    - Enhanced `queryParam` function to handle navigation states effectively.
    - Introduced a subscription mechanism to manage subscriptions and navigation events.
    - Added functionality to update `param2` when `param1` changes using query parameters.
- **Tests**
    - Added a test case to verify correct URL search parameter updates when changing multiple parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->