### PR TITLE
Fix the override setting to allow for false values

### DIFF
--- a/.changeset/modern-llamas-bow.md
+++ b/.changeset/modern-llamas-bow.md
@@ -1,0 +1,5 @@
+---
+"sveltekit-search-params": patch
+---
+
+Fix the override setting to allow for false values

--- a/src/lib/sveltekit-search-params.ts
+++ b/src/lib/sveltekit-search-params.ts
@@ -379,7 +379,7 @@ export function queryParam<T = string>(
 	const { subscribe } = derived<[typeof page, typeof override], T | null>(
 		[page, override],
 		([$page, $override], set) => {
-			if ($override) {
+			if ($override != null) {
 				if (isComplexEqual(currentValue, $override, equalityFn)) {
 					return;
 				}

--- a/src/lib/sveltekit-search-params.ts
+++ b/src/lib/sveltekit-search-params.ts
@@ -379,7 +379,7 @@ export function queryParam<T = string>(
 	const { subscribe } = derived<[typeof page, typeof override], T | null>(
 		[page, override],
 		([$page, $override], set) => {
-			if ($override != null) {
+			if ($override != undefined) {
 				if (isComplexEqual(currentValue, $override, equalityFn)) {
 					return;
 				}


### PR DESCRIPTION
Hi @paoloricciuti 👋 

I found a small bug when using the package with a store value that was a boolean, and by default `false`. I had this mount on a form submit after which a checkbox component would be mounted, mapped to a queryParam store that was of type boolean and by default false. It caused this weird infinite redirect loop, here is a little video of it:

https://github.com/paoloricciuti/sveltekit-search-params/assets/34274090/042fc7a7-e133-4633-9798-4e817b78dad0

Was able to trace it down to an evaluation of `$override` which wouldn't work for `false` values. Changed it to do a comparison of `null` which should be a bit safer, as the type of this is `T | null`, so I assume that we want this path to run only when non-null.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved the accuracy of query parameter handling by ensuring only non-null values affect the control flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->