### PR TITLE
fix: avoid complex values default being overriden on write

### DIFF
--- a/.changeset/twelve-weeks-drive.md
+++ b/.changeset/twelve-weeks-drive.md
@@ -1,0 +1,5 @@
+---
+"sveltekit-search-params": patch
+---
+
+fix: avoid complex values default being overriden on write

--- a/playground/src/routes/default/obj/+page.svelte
+++ b/playground/src/routes/default/obj/+page.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import { queryParam, ssp } from 'sveltekit-search-params';
+
+	const obj = queryParam('obj', ssp.object({ test: '' }));
+</script>
+
+<a href="/default/obj">reset</a>
+
+{#if $obj}
+	<input bind:value={$obj.test} />
+{/if}

--- a/playground/src/routes/default/parameters-obj/+page.svelte
+++ b/playground/src/routes/default/parameters-obj/+page.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import { queryParameters, ssp } from 'sveltekit-search-params';
+
+	const obj = queryParameters({ obj: ssp.object({ test: '' }) });
+</script>
+
+<a href="/default/parameters-obj">reset</a>
+
+{#if $obj.obj}
+	<input bind:value={$obj.obj.test} />
+{/if}

--- a/src/lib/sveltekit-search-params.ts
+++ b/src/lib/sveltekit-search-params.ts
@@ -281,13 +281,13 @@ export function queryParameters<T extends object>(
 				options,
 			);
 			if (anyDefaultedParam && showDefaults) {
-				_set(valueToSet, firstTime);
+				_set(structuredClone(valueToSet), firstTime);
 			}
 			if (isComplexEqual(currentValue, valueToSet, equalityFn)) {
 				return;
 			}
 			currentValue = structuredClone(valueToSet);
-			return set(valueToSet);
+			return set(structuredClone(valueToSet));
 		},
 	);
 	return {
@@ -389,13 +389,13 @@ export function queryParam<T = string>(
 			const actualParam = $page?.url?.searchParams?.get?.(name);
 			if (actualParam == undefined && defaultValue != undefined) {
 				if (showDefaults) {
-					_set(defaultValue, firstTime);
+					_set(structuredClone(defaultValue), firstTime);
 				}
 				if (isComplexEqual(currentValue, defaultValue, equalityFn)) {
 					return;
 				}
 				currentValue = structuredClone(defaultValue);
-				return set(defaultValue);
+				return set(structuredClone(defaultValue));
 			}
 			const retval = decode(actualParam);
 			if (isComplexEqual(currentValue, retval, equalityFn)) {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -381,6 +381,30 @@ test.describe('default values', () => {
 		expect(url.searchParams.get('str-no-show')).toBeNull();
 		expect(url.searchParams.get('str2-no-show')).toBeNull();
 	});
+
+	test("default values for complex values doesn't get override on writes", async ({
+		page,
+	}) => {
+		await page.goto('/default/obj');
+		const input = page.locator('input');
+		input.fill('test');
+		const link = page.locator('a');
+		await link.click();
+		const url = new URL(page.url());
+		expect(url.searchParams.get('obj')).toBe('{"test":""}');
+	});
+
+	test("default values for complex values doesn't get override on writes (queryParameters)", async ({
+		page,
+	}) => {
+		await page.goto('/default/parameters-obj');
+		const input = page.locator('input');
+		input.fill('test');
+		const link = page.locator('a');
+		await link.click();
+		const url = new URL(page.url());
+		expect(url.searchParams.get('obj')).toBe('{"test":""}');
+	});
 });
 
 test.describe('debounce history entry', () => {


### PR DESCRIPTION
Closes #86 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new Svelte components for managing query parameters with enhanced type safety.
	- Added functionality to reset query parameters via navigation links.
- **Bug Fixes**
	- Resolved an issue preventing complex values from being preserved during write operations in the search parameters.
- **Tests**
	- Added new tests to verify that default values for complex objects remain unchanged during write operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->