### PR TITLE
docs: Add documentation for updating multiple parameters at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ this will make the query parameter change as soon as the page is rendered on the
 
 > **Warning**
 >
-> You can't run `goto` on the server so if the page is server side rendered it will still have the null value (this is to say don't relay on the assumption that the store will always be not null).
+> You can't run `goto` on the server so if the page is server side rendered it will still have the null value (this is to say don't rely on the assumption that the store will always be not null).
 
 ### Helpers encodings and decodings
 
@@ -214,6 +214,35 @@ Just like with the single parameter case you can just update the store and the U
 ```
 
 writing in the input will update the state and the URL at the same time.
+
+### Updating multiple parameters at once
+
+When using `queryParameters` if you need to update multiple different parameters at once you will want to use the `update()` method to update the store to prevent multiple calls of `goto()`.
+
+```svelte
+<script lang="ts">
+	import { queryParameters } from 'sveltekit-search-params';
+
+	const store = queryParameters();
+
+	const update = (value) => {
+		store.update((v) => {
+			return {
+				...v,
+				from: value.from,
+				to: value.to,
+				period: value.period,
+			};
+		});
+	};
+</script>
+
+<SomeComponent onUpdate={update} />
+```
+
+> **Warning**
+>
+> If you don't use the update and instead individually assign each property on the store you may get `sveltekit 'client.js Uncaught (in promise) Error: navigation aborted'` errors.
 
 ### Expecting some parameters
 


### PR DESCRIPTION
Adds guidance in the README on how to handle updating multiple parameters at once.

- Fixes #105

(Removes all the unnecessary changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced the README.md with improved clarity on handling query parameters in SvelteKit.
	- Corrected a typographical error for better understanding.
	- Added a new section on updating multiple parameters at once, including a code example.
	- Provided warnings to prevent navigation errors when managing the queryParameters store.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->