### PR TITLE
#78 and #72 Hide default params when showDefaults is False and the va…

### DIFF
--- a/src/lib/sveltekit-search-params.ts
+++ b/src/lib/sveltekit-search-params.ts
@@ -298,6 +298,12 @@ export function queryParameters<
 				}
 				const newValue = fnToCall((value as any)[field]);
 				if (newValue == undefined) {
+                    query.delete(field as string);
+                } else if (
+                    !showDefaults &&
+                    newValue ===
+                    fnToCall((optionsKey as EncodeAndDecodeOptions)?.defaultValue)
+                ) {
 					query.delete(field as string);
 				} else {
 					query.set(field as string, newValue);
@@ -411,6 +417,8 @@ export function queryParam<T = string>(
 				const newValue = encode(value);
 				if (newValue == undefined) {
 					query.delete(name);
+                } else if (!showDefaults && newValue === encode(defaultValue)) {
+                    query.delete(name)
 				} else {
 					query.set(name, newValue);
 				}

--- a/src/lib/sveltekit-search-params.ts
+++ b/src/lib/sveltekit-search-params.ts
@@ -298,12 +298,15 @@ export function queryParameters<
 				}
 				const newValue = fnToCall((value as any)[field]);
 				if (newValue == undefined) {
-                    query.delete(field as string);
-                } else if (
-                    !showDefaults &&
-                    newValue ===
-                    fnToCall((optionsKey as EncodeAndDecodeOptions)?.defaultValue)
-                ) {
+					query.delete(field as string);
+				} else if (
+					!showDefaults &&
+					newValue ===
+						fnToCall(
+							(optionsKey as EncodeAndDecodeOptions)
+								?.defaultValue,
+						)
+				) {
 					query.delete(field as string);
 				} else {
 					query.set(field as string, newValue);
@@ -417,8 +420,8 @@ export function queryParam<T = string>(
 				const newValue = encode(value);
 				if (newValue == undefined) {
 					query.delete(name);
-                } else if (!showDefaults && newValue === encode(defaultValue)) {
-                    query.delete(name)
+				} else if (!showDefaults && newValue === encode(defaultValue)) {
+					query.delete(name);
 				} else {
 					query.set(name, newValue);
 				}


### PR DESCRIPTION
#78 and #72 Hide default params when showDefaults is False and the values are equivalent to the default.

Note: I didn't go deep into how the code works, but did this patch showing how I would expect the plugin to behave, and how the authors of #78 and #72 also expect it to behave as far as I can tell.

Maybe there's a better implementation but this was simple enough and seemed to do the trick. Tests didn't run when I pulled the repo so I didn't add new ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved handling of query parameters for better management and control.
	- Enhanced logic to automatically delete unnecessary query parameters based on specific conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->