### PR TITLE
fix(type): `decode` and `encode` should be optional

### DIFF
--- a/src/lib/sveltekit-search-params.ts
+++ b/src/lib/sveltekit-search-params.ts
@@ -374,12 +374,12 @@ const DEFAULT_ENCODER_DECODER: EncodeAndDecodeOptions = {
 
 export function queryParam<T>(
 	name: string,
-	options: EncodeAndDecodeOptions<T> & { defaultValue: T },
+	options: Partial<EncodeAndDecodeOptions<T>> & { defaultValue: T },
 	storeOptions?: StoreOptions<T>,
 ): Writable<T>;
 export function queryParam<T = string>(
 	name: string,
-	options?: EncodeAndDecodeOptions<T>,
+	options?: Partial<EncodeAndDecodeOptions<T>>,
 	storeOptions?: StoreOptions<T>,
 ): Writable<T | null>;
 export function queryParam<T = string>(
@@ -388,7 +388,7 @@ export function queryParam<T = string>(
 		encode: encode = DEFAULT_ENCODER_DECODER.encode,
 		decode: decode = DEFAULT_ENCODER_DECODER.decode,
 		defaultValue,
-	}: EncodeAndDecodeOptions<T> = DEFAULT_ENCODER_DECODER,
+	}: Partial<EncodeAndDecodeOptions<T>> = DEFAULT_ENCODER_DECODER,
 	{
 		debounceHistory = 0,
 		pushHistory = true,


### PR DESCRIPTION
This pull request includes changes to the `src/lib/sveltekit-search-params.ts` file to make the `EncodeAndDecodeOptions` parameter optional in the `queryParam` function. The most important changes involve modifying the type of the `options` parameter to `Partial<EncodeAndDecodeOptions<T>>`.

Changes to function parameters:

* [`src/lib/sveltekit-search-params.ts`](diffhunk://#diff-e1457f428bac3fe5a8171f674fb8e48c3cdf08e4c8b91fd6d9f99ef3a90b6ad5L377-R382): Modified the `options` parameter in the `queryParam` function to be of type `Partial<EncodeAndDecodeOptions<T>>` instead of `EncodeAndDecodeOptions<T>`. This change was applied to both overloads of the function.
* [`src/lib/sveltekit-search-params.ts`](diffhunk://#diff-e1457f428bac3fe5a8171f674fb8e48c3cdf08e4c8b91fd6d9f99ef3a90b6ad5L391-R391): Updated the destructuring assignment in the `queryParam` function to use `Partial<EncodeAndDecodeOptions<T>>` for the `encode`, `decode`, and `defaultValue` properties.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility in the `queryParam` function, allowing partial definitions of encoding and decoding options while requiring a default value.
- **Bug Fixes**
	- Updated method signatures to improve usability and compatibility with various options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->