### PR TITLE
feat: add $parsed to get only defined params

### DIFF
--- a/src/lib/sveltekit-search-params.svelte.ts
+++ b/src/lib/sveltekit-search-params.svelte.ts
@@ -198,7 +198,10 @@ function create_recursive_proxy<
 	navigator?: ReturnType<typeof create_root_navigator>,
 ) {
 	return new Proxy<LooseAutocomplete<Options<T>>>(
-		target as LooseAutocomplete<Options<T>>,
+		target as LooseAutocomplete<Options<T>> & {
+			toJSON: () => Options<T>,
+			$parsed: () => Options<T>
+		},
 		{
 			get(target, name) {
 				// we use the RAW symbol to get the original target (this is currently not used but better have it)
@@ -233,6 +236,16 @@ function create_recursive_proxy<
 								(values as any)[key] = value;
 							}
 						}
+						return values;
+					};
+				}
+				// special case for JSON.stringify
+				if (name === '$parsed') {
+					return () => {
+						// snapshot the cache
+						const values = $state.snapshot(cache);
+						// on the server that's enough
+						if (!browser) return values;
 						return values;
 					};
 				}
@@ -326,7 +339,10 @@ export function queryParameters<
 >(
 	options?: T,
 	navigation_options: NavigationOptions = {},
-): LooseAutocomplete<Options<T>> {
+): LooseAutocomplete<Options<T>> & {
+	toJSON: () => Options<T>;
+	$parsed: () => Options<T>
+} {
 	const { showDefaults: show_defaults = true } = navigation_options;
 	// keeps all the deriveds for every single property
 	const cache: Partial<T> = {};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,6 +2,7 @@
   import BrowserWindow from "./BrowserWindow.svelte";
   import "../assets/fonts.css";
   import { typewriter } from "svelte-typewriter-store";
+	import Demo from "./Demo.svelte";
   const store = typewriter(["pablopang", "rich_harris", "albert_einstein"], 30);
 </script>
 
@@ -35,6 +36,7 @@
   <code class="npm">npm i sveltekit-search-params -D</code>
 </div>
 <div class="wrapper">
+  <Demo />
   <BrowserWindow title="" url={`https://my.app?username=${$store}`}>
     <div class="content">
       <input readonly value={$store} /> <br />

--- a/src/routes/Demo.svelte
+++ b/src/routes/Demo.svelte
@@ -1,0 +1,18 @@
+<script>
+	import { queryParameters, ssp } from "$lib";
+
+    const params = queryParameters({
+        q: ssp.string(),
+        page: ssp.number(1)
+    })
+
+    let parsed = $derived(params.$parsed());
+</script>
+
+Defined: {JSON.stringify(parsed)}<br>
+All: {JSON.stringify(params.toJSON())}
+<br><br>
+<input bind:value={params.q}/><br>
+<button disabled={params.page < 2} onclick={() => params.page--}>Previous</button>
+<button onclick={() => params.page++}>Next</button><br>
+<br>


### PR DESCRIPTION
Fixes #179 and also the types as discussed here https://github.com/paoloricciuti/sveltekit-search-params/issues/177#issuecomment-3288295570

This is a draft / proof-of-concept for a potential new feature in queryParameters:

1. $parsed helper – returns a plain object containing only the keys defined in the query parameters.
Unlike toJSON, it ignores extra URL params like UTM tags or tracking parameters.
Provides a clean, whitelist-based snapshot of the parameters you explicitly defined.

2. toJSON typing fix – updated the return type of toJSON to correctly reflect the decoded shape of the defined query parameters.

We can have something like `$parseDefined()`, `$parseAll()` etc
### Notes:

This PR is just an idea and meant to start discussion.

### Open for feedback on:
- The name $parsed
- Implementation details and typing
- Any alternative approaches